### PR TITLE
세션 도메인에 UserId/ViewerId VO 적용 및 Redis/JPA 매핑 업데이트

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation project(':common')
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/api/src/main/java/org/heureum/api/config/CoreStreamConfiguration.java
+++ b/api/src/main/java/org/heureum/api/config/CoreStreamConfiguration.java
@@ -1,12 +1,17 @@
 package org.heureum.api.config;
 
-import org.heureum.api.session.infra.InMemoryStreamSessionRepository;
+import org.heureum.api.session.infra.jpa.StreamSessionJpaRepository;
+import org.heureum.api.session.infra.jpa.StreamSessionRepositoryJpaAdapter;
+import org.heureum.api.session.infra.redis.ViewerSessionRedisRepository;
 import org.heureum.common.time.SystemTimeProvider;
 import org.heureum.common.time.TimeProvider;
 import org.heureum.core.repository.session.StreamSessionRepository;
+import org.heureum.core.repository.session.ViewerSessionRepository;
 import org.heureum.core.service.session.StreamSessionService;
+import org.heureum.core.service.session.ViewerSessionService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.StringRedisTemplate;
 
 @Configuration
 public class CoreStreamConfiguration {
@@ -17,8 +22,8 @@ public class CoreStreamConfiguration {
     }
 
     @Bean
-    public StreamSessionRepository streamSessionRepository() {
-        return new InMemoryStreamSessionRepository();
+    public StreamSessionRepository streamSessionRepository(StreamSessionJpaRepository jpaRepository) {
+        return new StreamSessionRepositoryJpaAdapter(jpaRepository);
     }
 
     @Bean
@@ -27,5 +32,18 @@ public class CoreStreamConfiguration {
             TimeProvider timeProvider
     ) {
         return new StreamSessionService(repository, timeProvider);
+    }
+
+    @Bean
+    public ViewerSessionRepository viewerSessionRepository(StringRedisTemplate redisTemplate) {
+        return new ViewerSessionRedisRepository(redisTemplate);
+    }
+
+    @Bean
+    public ViewerSessionService viewerSessionService(
+            ViewerSessionRepository repository,
+            TimeProvider timeProvider
+    ) {
+        return new ViewerSessionService(repository, timeProvider);
     }
 }

--- a/api/src/main/java/org/heureum/api/session/api/StreamSessionController.java
+++ b/api/src/main/java/org/heureum/api/session/api/StreamSessionController.java
@@ -37,8 +37,8 @@ public class StreamSessionController {
         StreamSession session = sessionService.startSession(streamId, request.userId());
         return new StartSessionResponse(
                 session.getSessionId(),
-                session.getStreamId(),
-                session.getUserId(),
+                session.getStreamId().value(),
+                session.getUserId().value(),
                 session.getStartedAt()
         );
     }

--- a/api/src/main/java/org/heureum/api/session/api/ViewerSessionController.java
+++ b/api/src/main/java/org/heureum/api/session/api/ViewerSessionController.java
@@ -1,0 +1,76 @@
+package org.heureum.api.session.api;
+
+import jakarta.validation.Valid;
+import org.heureum.api.session.api.dto.ViewerSessionDtos.StartViewerSessionRequest;
+import org.heureum.api.session.api.dto.ViewerSessionDtos.ViewerSessionResponse;
+import org.heureum.core.domain.session.ViewerSession;
+import org.heureum.core.service.session.ViewerSessionService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+
+@RestController
+@RequestMapping("/api/streams")
+public class ViewerSessionController {
+    private final ViewerSessionService viewerSessionService;
+
+    public ViewerSessionController(ViewerSessionService viewerSessionService) {
+        this.viewerSessionService = viewerSessionService;
+    }
+
+    @PostMapping("/{streamId}/viewers/sessions")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ViewerSessionResponse startSession(
+            @PathVariable String streamId,
+            @Valid @RequestBody StartViewerSessionRequest request,
+            @RequestParam(defaultValue = "60") long ttlSeconds
+    ) {
+        ViewerSession session = viewerSessionService.startSession(
+                streamId,
+                request.viewerId(),
+                Duration.ofSeconds(ttlSeconds)
+        );
+        return new ViewerSessionResponse(
+                session.getStreamId().value(),
+                session.getViewerId().value(),
+                session.getConnectedAt(),
+                session.getLastHeartbeatAt()
+        );
+    }
+
+    @PostMapping("/{streamId}/viewers/{viewerId}/heartbeat")
+    public ViewerSessionResponse heartbeat(
+            @PathVariable String streamId,
+            @PathVariable String viewerId,
+            @RequestParam(defaultValue = "60") long ttlSeconds
+    ) {
+        ViewerSession session = viewerSessionService.heartbeat(
+                streamId,
+                viewerId,
+                Duration.ofSeconds(ttlSeconds)
+        );
+        return new ViewerSessionResponse(
+                session.getStreamId().value(),
+                session.getViewerId().value(),
+                session.getConnectedAt(),
+                session.getLastHeartbeatAt()
+        );
+    }
+
+    @DeleteMapping("/{streamId}/viewers/{viewerId}/sessions")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void endSession(
+            @PathVariable String streamId,
+            @PathVariable String viewerId
+    ) {
+        viewerSessionService.endSession(streamId, viewerId);
+    }
+}

--- a/api/src/main/java/org/heureum/api/session/api/dto/ViewerSessionDtos.java
+++ b/api/src/main/java/org/heureum/api/session/api/dto/ViewerSessionDtos.java
@@ -1,0 +1,19 @@
+package org.heureum.api.session.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.Instant;
+
+public final class ViewerSessionDtos {
+    private ViewerSessionDtos() {
+    }
+
+    public record StartViewerSessionRequest(@NotBlank String viewerId) {
+    }
+
+    public record ViewerSessionResponse(String streamId,
+                                        String viewerId,
+                                        Instant connectedAt,
+                                        Instant lastHeartbeatAt) {
+    }
+}

--- a/api/src/main/java/org/heureum/api/session/infra/InMemoryStreamSessionRepository.java
+++ b/api/src/main/java/org/heureum/api/session/infra/InMemoryStreamSessionRepository.java
@@ -1,6 +1,7 @@
 package org.heureum.api.session.infra;
 
 import org.heureum.core.domain.session.StreamSession;
+import org.heureum.core.domain.stream.StreamId;
 import org.heureum.core.repository.session.StreamSessionRepository;
 
 import java.util.ArrayList;
@@ -24,7 +25,7 @@ public class InMemoryStreamSessionRepository implements StreamSessionRepository 
     }
 
     @Override
-    public List<StreamSession> findByStreamId(String streamId) {
+    public List<StreamSession> findByStreamId(StreamId streamId) {
         List<StreamSession> result = new ArrayList<>();
         for (StreamSession session : sessions.values()) {
             if (session.getStreamId().equals(streamId)) {

--- a/api/src/main/java/org/heureum/api/session/infra/jpa/StreamSessionJpaEntity.java
+++ b/api/src/main/java/org/heureum/api/session/infra/jpa/StreamSessionJpaEntity.java
@@ -1,0 +1,55 @@
+package org.heureum.api.session.infra.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.heureum.core.domain.session.StreamSessionStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "stream_sessions")
+@NoArgsConstructor
+public class StreamSessionJpaEntity {
+
+    @Id
+    @Column(nullable = false, updatable = false)
+    private UUID sessionId;
+
+    @Column(nullable = false)
+    private String streamId;
+
+    @Column(nullable = false)
+    private String userId;
+
+    @Column(nullable = false)
+    private Instant startedAt;
+
+    @Column(nullable = false)
+    private Instant lastHeartbeatAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private StreamSessionStatus status;
+
+    public StreamSessionJpaEntity(UUID sessionId,
+                                  String streamId,
+                                  String userId,
+                                  Instant startedAt,
+                                  Instant lastHeartbeatAt,
+                                  StreamSessionStatus status) {
+        this.sessionId = sessionId;
+        this.streamId = streamId;
+        this.userId = userId;
+        this.startedAt = startedAt;
+        this.lastHeartbeatAt = lastHeartbeatAt;
+        this.status = status;
+    }
+}

--- a/api/src/main/java/org/heureum/api/session/infra/jpa/StreamSessionJpaRepository.java
+++ b/api/src/main/java/org/heureum/api/session/infra/jpa/StreamSessionJpaRepository.java
@@ -1,0 +1,10 @@
+package org.heureum.api.session.infra.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface StreamSessionJpaRepository extends JpaRepository<StreamSessionJpaEntity, UUID> {
+    List<StreamSessionJpaEntity> findByStreamId(String streamId);
+}

--- a/api/src/main/java/org/heureum/api/session/infra/jpa/StreamSessionRepositoryJpaAdapter.java
+++ b/api/src/main/java/org/heureum/api/session/infra/jpa/StreamSessionRepositoryJpaAdapter.java
@@ -1,0 +1,55 @@
+package org.heureum.api.session.infra.jpa;
+
+import lombok.RequiredArgsConstructor;
+import org.heureum.core.domain.session.StreamSession;
+import org.heureum.core.domain.stream.StreamId;
+import org.heureum.core.domain.user.UserId;
+import org.heureum.core.repository.session.StreamSessionRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class StreamSessionRepositoryJpaAdapter implements StreamSessionRepository {
+    private final StreamSessionJpaRepository jpaRepository;
+
+    @Override
+    public StreamSession save(StreamSession session) {
+        StreamSessionJpaEntity entity = toEntity(session);
+        StreamSessionJpaEntity saved = jpaRepository.save(entity);
+        return toDomain(saved);
+    }
+
+    @Override
+    public Optional<StreamSession> findById(UUID sessionId) {
+        return jpaRepository.findById(sessionId).map(this::toDomain);
+    }
+
+    @Override
+    public List<StreamSession> findByStreamId(StreamId streamId) {
+        return jpaRepository.findByStreamId(streamId.value()).stream().map(this::toDomain).toList();
+    }
+
+    private StreamSessionJpaEntity toEntity(StreamSession session) {
+        return new StreamSessionJpaEntity(
+                session.getSessionId(),
+                session.getStreamId().value(),
+                session.getUserId().value(),
+                session.getStartedAt(),
+                session.getLastHeartbeatAt(),
+                session.getStatus()
+        );
+    }
+
+    private StreamSession toDomain(StreamSessionJpaEntity entity) {
+        return StreamSession.restore(
+                entity.getSessionId(),
+                StreamId.of(entity.getStreamId()),
+                UserId.of(entity.getUserId()),
+                entity.getStartedAt(),
+                entity.getLastHeartbeatAt(),
+                entity.getStatus()
+        );
+    }
+}

--- a/api/src/main/java/org/heureum/api/session/infra/redis/ViewerSessionRedisRepository.java
+++ b/api/src/main/java/org/heureum/api/session/infra/redis/ViewerSessionRedisRepository.java
@@ -1,0 +1,78 @@
+package org.heureum.api.session.infra.redis;
+
+import org.heureum.core.domain.session.ViewerSession;
+import org.heureum.core.domain.stream.StreamId;
+import org.heureum.core.domain.user.ViewerId;
+import org.heureum.core.repository.session.ViewerSessionRepository;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class ViewerSessionRedisRepository implements ViewerSessionRepository {
+    private static final String VIEWER_KEY_PREFIX = "viewer:stream_id:";
+    private static final String VIEWERS_SET_PREFIX = "stream:";
+    private static final String FIELD_STREAM_ID = "streamId";
+    private static final String FIELD_VIEWER_ID = "viewerId";
+    private static final String FIELD_CONNECTED_AT = "connectedAt";
+    private static final String FIELD_LAST_HEARTBEAT_AT = "lastHeartbeatAt";
+
+    private final StringRedisTemplate redisTemplate;
+    private final HashOperations<String, String, String> hashOps;
+    private final SetOperations<String, String> setOps;
+
+    public ViewerSessionRedisRepository(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+        this.hashOps = redisTemplate.opsForHash();
+        this.setOps = redisTemplate.opsForSet();
+    }
+
+    @Override
+    public ViewerSession save(ViewerSession session, Duration ttl) {
+        String viewerKey = viewerKey(session.getStreamId(), session.getViewerId());
+        String viewersKey = viewersKey(session.getStreamId());
+        Map<String, String> values = new HashMap<>();
+        values.put(FIELD_STREAM_ID, session.getStreamId().value());
+        values.put(FIELD_VIEWER_ID, session.getViewerId().value());
+        values.put(FIELD_CONNECTED_AT, String.valueOf(session.getConnectedAt().toEpochMilli()));
+        values.put(FIELD_LAST_HEARTBEAT_AT, String.valueOf(session.getLastHeartbeatAt().toEpochMilli()));
+        hashOps.putAll(viewerKey, values);
+        redisTemplate.expire(viewerKey, ttl);
+        setOps.add(viewersKey, session.getViewerId().value());
+        return session;
+    }
+
+    @Override
+    public Optional<ViewerSession> findByStreamIdAndViewerId(StreamId streamId, ViewerId viewerId) {
+        String viewerKey = viewerKey(streamId, viewerId);
+        Map<String, String> entries = hashOps.entries(viewerKey);
+        if (entries == null || entries.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(ViewerSession.restore(
+                StreamId.of(entries.get(FIELD_STREAM_ID)),
+                ViewerId.of(entries.get(FIELD_VIEWER_ID)),
+                Instant.ofEpochMilli(Long.parseLong(entries.get(FIELD_CONNECTED_AT))),
+                Instant.ofEpochMilli(Long.parseLong(entries.get(FIELD_LAST_HEARTBEAT_AT)))
+        ));
+    }
+
+    @Override
+    public void delete(StreamId streamId, ViewerId viewerId) {
+        redisTemplate.delete(viewerKey(streamId, viewerId));
+        setOps.remove(viewersKey(streamId), viewerId.value());
+    }
+
+    private String viewerKey(StreamId streamId, ViewerId viewerId) {
+        return VIEWER_KEY_PREFIX + streamId.value() + ":viewer_id:" + viewerId.value();
+    }
+
+    private String viewersKey(StreamId streamId) {
+        return VIEWERS_SET_PREFIX + streamId.value() + ":viewers";
+    }
+}

--- a/core/src/main/java/org/heureum/core/domain/session/StreamSession.java
+++ b/core/src/main/java/org/heureum/core/domain/session/StreamSession.java
@@ -1,6 +1,8 @@
 package org.heureum.core.domain.session;
 
 import lombok.Getter;
+import org.heureum.core.domain.stream.StreamId;
+import org.heureum.core.domain.user.UserId;
 
 import java.time.Instant;
 import java.util.Objects;
@@ -9,19 +11,28 @@ import java.util.UUID;
 @Getter
 public final class StreamSession {
     private final UUID sessionId;
-    private final String streamId;
-    private final String userId;
+    private final StreamId streamId;
+    private final UserId userId;
     private final Instant startedAt;
     private Instant lastHeartbeatAt;
     private StreamSessionStatus status;
 
-    public StreamSession(UUID sessionId, String streamId, String userId, Instant startedAt) {
+    public StreamSession(UUID sessionId, StreamId streamId, UserId userId, Instant startedAt) {
+        this(sessionId, streamId, userId, startedAt, startedAt, StreamSessionStatus.ACTIVE);
+    }
+
+    private StreamSession(UUID sessionId,
+                          StreamId streamId,
+                          UserId userId,
+                          Instant startedAt,
+                          Instant lastHeartbeatAt,
+                          StreamSessionStatus status) {
         this.sessionId = Objects.requireNonNull(sessionId, "sessionId");
         this.streamId = Objects.requireNonNull(streamId, "streamId");
         this.userId = Objects.requireNonNull(userId, "userId");
         this.startedAt = Objects.requireNonNull(startedAt, "startedAt");
-        this.lastHeartbeatAt = startedAt;
-        this.status = StreamSessionStatus.ACTIVE;
+        this.lastHeartbeatAt = Objects.requireNonNull(lastHeartbeatAt, "lastHeartbeatAt");
+        this.status = Objects.requireNonNull(status, "status");
     }
 
     public void heartbeat(Instant heartbeatAt) {
@@ -38,5 +49,14 @@ public final class StreamSession {
         }
         this.lastHeartbeatAt = endedAt;
         this.status = StreamSessionStatus.ENDED;
+    }
+
+    public static StreamSession restore(UUID sessionId,
+                                        StreamId streamId,
+                                        UserId userId,
+                                        Instant startedAt,
+                                        Instant lastHeartbeatAt,
+                                        StreamSessionStatus status) {
+        return new StreamSession(sessionId, streamId, userId, startedAt, lastHeartbeatAt, status);
     }
 }

--- a/core/src/main/java/org/heureum/core/domain/session/ViewerSession.java
+++ b/core/src/main/java/org/heureum/core/domain/session/ViewerSession.java
@@ -1,0 +1,41 @@
+package org.heureum.core.domain.session;
+
+import lombok.Getter;
+import org.heureum.core.domain.stream.StreamId;
+import org.heureum.core.domain.user.ViewerId;
+
+import java.time.Instant;
+import java.util.Objects;
+
+@Getter
+public final class ViewerSession {
+    private final StreamId streamId;
+    private final ViewerId viewerId;
+    private final Instant connectedAt;
+    private Instant lastHeartbeatAt;
+
+    public ViewerSession(StreamId streamId, ViewerId viewerId, Instant connectedAt) {
+        this(streamId, viewerId, connectedAt, connectedAt);
+    }
+
+    private ViewerSession(StreamId streamId,
+                          ViewerId viewerId,
+                          Instant connectedAt,
+                          Instant lastHeartbeatAt) {
+        this.streamId = Objects.requireNonNull(streamId, "streamId");
+        this.viewerId = Objects.requireNonNull(viewerId, "viewerId");
+        this.connectedAt = Objects.requireNonNull(connectedAt, "connectedAt");
+        this.lastHeartbeatAt = Objects.requireNonNull(lastHeartbeatAt, "lastHeartbeatAt");
+    }
+
+    public void heartbeat(Instant heartbeatAt) {
+        this.lastHeartbeatAt = Objects.requireNonNull(heartbeatAt, "heartbeatAt");
+    }
+
+    public static ViewerSession restore(StreamId streamId,
+                                        ViewerId viewerId,
+                                        Instant connectedAt,
+                                        Instant lastHeartbeatAt) {
+        return new ViewerSession(streamId, viewerId, connectedAt, lastHeartbeatAt);
+    }
+}

--- a/core/src/main/java/org/heureum/core/domain/user/UserId.java
+++ b/core/src/main/java/org/heureum/core/domain/user/UserId.java
@@ -1,0 +1,29 @@
+package org.heureum.core.domain.user;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public final class UserId {
+    private final String value;
+
+    private UserId(String value) {
+        this.value = Objects.requireNonNull(value, "value");
+    }
+
+    public static UserId newId() {
+        return new UserId(UUID.randomUUID().toString());
+    }
+
+    public static UserId of(String value) {
+        return new UserId(value);
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/core/src/main/java/org/heureum/core/domain/user/ViewerId.java
+++ b/core/src/main/java/org/heureum/core/domain/user/ViewerId.java
@@ -1,0 +1,29 @@
+package org.heureum.core.domain.user;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public final class ViewerId {
+    private final String value;
+
+    private ViewerId(String value) {
+        this.value = Objects.requireNonNull(value, "value");
+    }
+
+    public static ViewerId newId() {
+        return new ViewerId(UUID.randomUUID().toString());
+    }
+
+    public static ViewerId of(String value) {
+        return new ViewerId(value);
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/core/src/main/java/org/heureum/core/repository/session/StreamSessionRepository.java
+++ b/core/src/main/java/org/heureum/core/repository/session/StreamSessionRepository.java
@@ -1,6 +1,7 @@
 package org.heureum.core.repository.session;
 
 import org.heureum.core.domain.session.StreamSession;
+import org.heureum.core.domain.stream.StreamId;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,5 +12,5 @@ public interface StreamSessionRepository {
 
     Optional<StreamSession> findById(UUID sessionId);
 
-    List<StreamSession> findByStreamId(String streamId);
+    List<StreamSession> findByStreamId(StreamId streamId);
 }

--- a/core/src/main/java/org/heureum/core/repository/session/ViewerSessionRepository.java
+++ b/core/src/main/java/org/heureum/core/repository/session/ViewerSessionRepository.java
@@ -1,0 +1,16 @@
+package org.heureum.core.repository.session;
+
+import org.heureum.core.domain.session.ViewerSession;
+import org.heureum.core.domain.stream.StreamId;
+import org.heureum.core.domain.user.ViewerId;
+
+import java.time.Duration;
+import java.util.Optional;
+
+public interface ViewerSessionRepository {
+    ViewerSession save(ViewerSession session, Duration ttl);
+
+    Optional<ViewerSession> findByStreamIdAndViewerId(StreamId streamId, ViewerId viewerId);
+
+    void delete(StreamId streamId, ViewerId viewerId);
+}

--- a/core/src/main/java/org/heureum/core/service/session/ViewerSessionService.java
+++ b/core/src/main/java/org/heureum/core/service/session/ViewerSessionService.java
@@ -1,0 +1,49 @@
+package org.heureum.core.service.session;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.heureum.common.time.TimeProvider;
+import org.heureum.core.domain.session.ViewerSession;
+import org.heureum.core.domain.stream.StreamId;
+import org.heureum.core.domain.user.ViewerId;
+import org.heureum.core.repository.session.ViewerSessionRepository;
+
+import java.time.Duration;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+public class ViewerSessionService {
+    private final @NonNull ViewerSessionRepository repository;
+    private final @NonNull TimeProvider timeProvider;
+
+    public ViewerSession startSession(String streamId, String viewerId, Duration ttl) {
+        StreamId stream = StreamId.of(requireId(streamId, "streamId"));
+        ViewerId viewer = ViewerId.of(requireId(viewerId, "viewerId"));
+        Objects.requireNonNull(ttl, "ttl");
+        ViewerSession session = new ViewerSession(stream, viewer, timeProvider.now());
+        return repository.save(session, ttl);
+    }
+
+    public ViewerSession heartbeat(String streamId, String viewerId, Duration ttl) {
+        StreamId stream = StreamId.of(requireId(streamId, "streamId"));
+        ViewerId viewer = ViewerId.of(requireId(viewerId, "viewerId"));
+        Objects.requireNonNull(ttl, "ttl");
+        ViewerSession session = repository.findByStreamIdAndViewerId(stream, viewer)
+                .orElseThrow(() -> new IllegalArgumentException("Viewer session not found."));
+        session.heartbeat(timeProvider.now());
+        return repository.save(session, ttl);
+    }
+
+    public void endSession(String streamId, String viewerId) {
+        StreamId stream = StreamId.of(requireId(streamId, "streamId"));
+        ViewerId viewer = ViewerId.of(requireId(viewerId, "viewerId"));
+        repository.delete(stream, viewer);
+    }
+
+    private String requireId(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank.");
+        }
+        return value;
+    }
+}

--- a/core/src/test/java/org/heureum/core/service/session/StreamSessionServiceTest.java
+++ b/core/src/test/java/org/heureum/core/service/session/StreamSessionServiceTest.java
@@ -3,6 +3,7 @@ package org.heureum.core.service.session;
 import org.heureum.common.time.TimeProvider;
 import org.heureum.core.domain.session.StreamSession;
 import org.heureum.core.domain.session.StreamSessionStatus;
+import org.heureum.core.domain.stream.StreamId;
 import org.heureum.core.repository.session.StreamSessionRepository;
 import org.junit.jupiter.api.Test;
 
@@ -113,7 +114,7 @@ class StreamSessionServiceTest {
         }
 
         @Override
-        public List<StreamSession> findByStreamId(String streamId) {
+        public List<StreamSession> findByStreamId(StreamId streamId) {
             List<StreamSession> result = new ArrayList<>();
             for (StreamSession session : sessions.values()) {
                 if (session.getStreamId().equals(streamId)) {


### PR DESCRIPTION
### Motivation
- 일관된 식별자 처리를 위해 세션 도메인 전반에서 `UserId` 및 `ViewerId` 값 객체(VO)를 도입했습니다.
- 원시 `String` 대신 VO를 사용하여 타입 안전성을 높이고 런타임 불일치 가능성을 줄입니다.
- 개별 뷰어 세션을 Redis에 TTL과 함께 저장하고 스트림별 집계 `Set`을 유지하도록 변경합니다.
- `StreamSession`에 대해 JPA 어댑터를 추가하여 관계형 DB에 세션을 영구화할 수 있게 합니다.

### Description
- `core/src/main/java/org/heureum/core/domain/user/UserId.java`와 `ViewerId.java`를 추가하고 `StreamSession`/`ViewerSession` 도메인에서 VO를 사용하도록 변경했습니다.
- 서비스와 리포지토리 시그니처(`StreamSessionService`, `ViewerSessionService`, `StreamSessionRepository`, `ViewerSessionRepository`) 및 컨트롤러에서 입력 `String`을 `StreamId.of(...)`, `UserId.of(...)`, `ViewerId.of(...)`로 변환하도록 갱신했습니다.
- Redis 저장소 구현인 `ViewerSessionRedisRepository`를 추가해 뷰어별 Hash 키에 TTL을 설정하고 스트림별 뷰어 `Set`을 유지하도록 했으며, JPA 엔티티 `StreamSessionJpaEntity`, `StreamSessionJpaRepository`, `StreamSessionRepositoryJpaAdapter`를 추가해 `StreamSession` ↔ JPA 매핑을 구현했습니다.
- API 레이어의 DTO/컨트롤러와 어댑터에서 VO ↔ `String` 변환(`.value()` 및 `UserId.of(...)`/`ViewerId.of(...)`)을 반영했습니다.

### Testing
- 자동화된 테스트는 이 변경에서 실행되지 않았습니다.
- 단위 테스트 파일 `core/src/test/java/org/heureum/core/service/session/StreamSessionServiceTest.java`는 VO 타입 변경을 반영하도록 업데이트되었으나 실행되지 않았습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695526607a78833084c9c5afc2d2f5f6)